### PR TITLE
Make sure to exit with non-zero exit code on hugo error

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -53,8 +53,13 @@ gulp.task("server", ["hugo", "css", "js"], () => {
 function buildSite(cb, options) {
   const args = options ? defaultArgs.concat(options) : defaultArgs;
 
-  return cp.spawn(hugoBin, args, {stdio: "inherit"}).on("close", () => {
-    browserSync.reload();
-    cb();
+  return cp.spawn(hugoBin, args, {stdio: "inherit"}).on("close", (code) => {
+    if (code === 0) {
+      browserSync.reload();
+      cb();
+    } else {
+      browserSync.notify("Hugo build failed :(");
+      cb("Hugo build failed");
+    }
   });
 }


### PR DESCRIPTION
If hugo fails to build the site, we want to make sure gulp exits
with an appropriate error code so a netlify deploy fails