### PR TITLE
Fix wrong directory for app.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm run build
 |  |--static           // Files in here ends up in the public folder
 |--src                 // Files that will pass through the asset pipeline
 |  |--css              // CSS files in the root of this folder will end up in /css/...
-|  |--js               // app.js will be compiled to /js/app.js with babel
+|  |--js               // app.js will be compiled to /app.js with babel
 ```
 
 ## Basic Concepts


### PR DESCRIPTION
The `app.js` file is being built to the site root, not a `js` subdirectory.  Update the README to reflect this.