### PR TITLE
Flip CSS tasks order to parse custom imports

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -20,7 +20,7 @@ gulp.task("build-preview", ["css", "js", "hugo-preview"]);
 
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
-    .pipe(postcss([cssnext(), cssImport({from: "./src/css/main.css"})]))
+    .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext()]))
     .pipe(gulp.dest("./dist/css"))
     .pipe(browserSync.stream())
 ));


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Fixes #22 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This change allows people to set custom imports in their main css file.

**- Test plan**

1. Create an imported css file and add it to the `main.css` file as described in #22.
2. Run `npm build`.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

- Fixed issue that prevented people from importing css files into the `main.css` file.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://pbs.twimg.com/profile_images/788160084266196992/U-GBnIJG.jpg)