### PR TITLE
Pin Hugo version on Netlify to the most recent one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ You can also click this button:
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/eliwilliamson/victor-hugo)
 
+### Picking the right version of Hugo
 
+Victor-Hugo doesn't make any assumption on which version of Hugo you use, this boilerplate works with any version above v0.13. However, the version
+installed on your computer might not be the same version that Netlify uses to build your site. To ensure that those two versions match, open the `netlify.toml`
+file and change the `HUGO_VERSION` variable to match the version you use in your computer. If you don't know which version you're using in your computer, you 
+can open a terminal and run `hugo version`, that will display the version in your computer.
 
 ## Enjoy!!

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 # Change the version of Hugo you want to use on Netlify
 # by changing this environment variable.
 [build.environment]
-  HUGO_VERSION = "0.21"
+  HUGO_VERSION = "v0.25.1"
 
 [context.deploy-preview]
   command = "npm run build-preview"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,10 @@
   command = "npm run build"
   publish = "dist"
 
+# Change the version of Hugo you want to use on Netlify
+# by changing this environment variable.
+[build.environment]
+  HUGO_VERSION = "0.21"
+
 [context.deploy-preview]
   command = "npm run build-preview"


### PR DESCRIPTION
So people start with a more modern version of Hugo when
they deploy their site on Netlify.

Signed-off-by: David Calavera <david.calavera@gmail.com>

<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This ensures that Netlify uses a more modern version of Hugo when a site built with Victor-Hugo is deployed for the first time.

New users of Victor-Hugo might bump into issues right away because Netlify's default version of Hugo is older than their version. This will help with that problem.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

Deploy a new site on Netlify.
Ensure that Netlify uses Hugo 0.21, the most recent version on May 30.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

- Pin version of Hugo for Netlify's deploy to a more recent one.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://sociorocketnewsen.files.wordpress.com/2016/06/capybara-on-head-3.jpg?w=580&h=435)