### PR TITLE
remove autoprefixer duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "autoprefixer": "^6.3.7",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",


### PR DESCRIPTION
**- Summary**

Included in Victor-Hugo's `package.json` are dependencies for `"autoprefixer": "^6.3.7"` and `"postcss-cssnext": "^2.7.0"`. However, [PostCSS CSSNext already has Autoprefixer baked in](http://cssnext.io/features/#automatic-vendor-prefixes), therefore seems it may be redundant to have the standalone. 

**- Test plan**

I tested and verified it is unnecessary with Gulp build first by installing and running Victor-Hugo `master` branch and adding `body { display: flex; }` in the `src/css/main.css` which then compiled to `body { display: -webkit-box; display: -ms-flexbox; display: flex; }`. 

I then removed the `node_modules/autoprefixer/` dir and ran `npm uninstall --save autoprefixer` to remove from `package.json` and replicated the same results were being output. 

**- Description for the changelog**

Remove autoprefixer duplicate dependency

![Imgur](https://i.imgur.com/kOjzup1.png)