### PR TITLE
remove unused postcss-loader as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "imports-loader": "^0.7.1",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^2.0.5",
     "url-loader": "^0.5.7",
     "webpack": "^2.6.0",
     "whatwg-fetch": "^1.0.0"


### PR DESCRIPTION
**- Summary**

In Victor-Hugo's `package.json` there is a declared dependency for `postcss-loader`. However, it is not being used anywhere, therefore it seems unnecessary to have it declared.

**- Test plan**

I removed the `postcss-loader` dependency from `package.json` with `npm uninstall --save postcss-loader` and ran `npm start` to verify there were not breaking changes in UI and in console output.

**- Description for the changelog**

remove unused postcss-loader as dependency

**- A picture of a cute animal (not mandatory but encouraged)**
![A picture of a cute animal](http://imgur.com/sa5pFu0.png)