### PR TITLE
Prevent exiting on css error

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,6 +21,7 @@ gulp.task("build-preview", ["css", "js", "hugo-preview"]);
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
     .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext()]))
+    .on("error", swallowError)
     .pipe(gulp.dest("./dist/css"))
     .pipe(browserSync.stream())
 ));
@@ -62,4 +63,9 @@ function buildSite(cb, options) {
       cb("Hugo build failed");
     }
   });
+}
+
+function swallowError(error) {
+  console.error(error.toString());
+  this.emit("end");
 }


### PR DESCRIPTION
When there's a css error, the `npm run start` command exits. This forces the user to run the command again. With this change, I simply swallowed the error and output to stderr.