### PR TITLE
Revert "Prevent exiting on css error"

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,7 +21,6 @@ gulp.task("build-preview", ["css", "js", "hugo-preview"]);
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
     .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext()]))
-    .on("error", swallowError)
     .pipe(gulp.dest("./dist/css"))
     .pipe(browserSync.stream())
 ));
@@ -63,9 +62,4 @@ function buildSite(cb, options) {
       cb("Hugo build failed");
     }
   });
-}
-
-function swallowError(error) {
-  console.error(error.toString());
-  this.emit("end");
 }


### PR DESCRIPTION
Reverts netlify/victor-hugo#32

@bryankang I've decided to revert this change. After thinking about it, people should not ignore those errors, otherwise they might end up with broken sites in production.