### PR TITLE
add default archetype ala 0.2.4

### DIFF
--- a/site/archetypes/default.md
+++ b/site/archetypes/default.md
@@ -1,0 +1,8 @@
++++
+title = "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+slug = ""
+tags = []
+categories = []
+draft = true
++++


### PR DESCRIPTION
**- Summary**

Following the docu on https://www.netlify.com/blog/2016/09/21/a-step-by-step-guide-victor-hugo-on-netlify/ I'd get `Error: open : no such file or directory` on running `hugo new about.md` (ala https://github.com/gohugoio/hugo/issues/3626). After reading about archetype changes in 0.24 I created a default one based upon https://gohugo.io/content/archetypes/ and https://github.com/gohugoio/hugo/releases/tag/v0.24. You may want to simplify it and leave out the slug/tags/categories placeholders.

**- Test plan**

Try `$ hugo new about.md` on a fresh install with v0.24 before and after this commit.

**- Description for the changelog**

Adds in a default archetype so new files can be created.