### PR TITLE
Include hugo as a npm dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,6 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Setup
 
-> Install Hugo in your system: https://github.com/spf13/hugo/releases
-
 ```sh
 $ git clone https://github.com/netlify/victor-hugo
 $ cd victor-hugo

--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ You can also click this button:
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/eliwilliamson/victor-hugo)
 
-### Picking the right version of Hugo
 
-Victor-Hugo doesn't make any assumption on which version of Hugo you use, this boilerplate works with any version above v0.13. However, the version
-installed on your computer might not be the same version that Netlify uses to build your site. To ensure that those two versions match, open the `netlify.toml`
-file and change the `HUGO_VERSION` variable to match the version you use in your computer. If you don't know which version you're using in your computer, you 
-can open a terminal and run `hugo version`, that will display the version in your computer.
 
 ## Enjoy!!

--- a/README.md
+++ b/README.md
@@ -11,15 +11,7 @@ This project is released under the [MIT license](LICENSE). Please make sure you 
 
 ## Usage
 
-Be sure that you have the latest node, npm and [Hugo](https://gohugo.io/) installed. If you need to install hugo on OSX, run:
-
-```bash
-brew install hugo
-```
-
-If you don't use OSX or don't use homebrew, follow the instructions for installation here instead:
-
-http://gohugo.io/overview/installing/
+Be sure that you have the latest node and npm installed.
 
 Next, clone this repository and run:
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,5 +1,6 @@
 import gulp from "gulp";
-import cp from "child_process";
+import { spawn } from "child_process";
+import hugoBin from "hugo-bin"
 import gutil from "gulp-util";
 import postcss from "gulp-postcss";
 import cssImport from "postcss-import";
@@ -9,7 +10,6 @@ import webpack from "webpack";
 import webpackConfig from "./webpack.conf";
 
 const browserSync = BrowserSync.create();
-const hugoBin = "hugo";
 const defaultArgs = ["-d", "../dist", "-s", "site", "-v"];
 
 gulp.task("hugo", (cb) => buildSite(cb));
@@ -53,7 +53,7 @@ gulp.task("server", ["hugo", "css", "js"], () => {
 function buildSite(cb, options) {
   const args = options ? defaultArgs.concat(options) : defaultArgs;
 
-  return cp.spawn(hugoBin, args, {stdio: "inherit"}).on("close", (code) => {
+  return spawn(hugoBin, args, {stdio: "inherit"}).on("close", (code) => {
     if (code === 0) {
       browserSync.reload();
       cb();

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,10 +2,5 @@
   command = "npm run build"
   publish = "dist"
 
-# Change the version of Hugo you want to use on Netlify
-# by changing this environment variable.
-[build.environment]
-  HUGO_VERSION = "v0.25.1"
-
 [context.deploy-preview]
   command = "npm run build-preview"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-postcss": "^6.1.1",
     "gulp-util": "^3.0.7",
-    "hugo-bin": "^0.11.0",
+    "hugo-bin": "^0.12.0",
     "imports-loader": "^0.7.1",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-postcss": "^6.1.1",
     "gulp-util": "^3.0.7",
+    "hugo-bin": "^0.11.0",
     "imports-loader": "^0.7.1",
     "postcss-cssnext": "^2.7.0",
     "postcss-import": "^10.0.0",


### PR DESCRIPTION
**- Summary**

Don't require hugo to be installed separately; instead add the node wrapper module [hugo-bin](https://www.npmjs.com/package/hugo-bin) as a npm dependency.

This PR simplifies the setup process and removes the need for users to go learn how to install hugo on their platform.

Instead they simply run `npm install` and hugo gets added to `node_modules/.bin`. In javascript we can pass `reauire('hugo-bin')` directly to `cp.spawn`.

---

hugo-bin ~~currently uses hugo [version 0.24.1](https://github.com/gohugoio/hugo/releases/tag/v0.24.1)~~, which can be updated via a simple change to the upstream `package.json` (see fenneclab/hugo-bin#23). _EDIT: Now uses latest version 0.25.1_

---

**- Test plan:** Existing tests should cover this change: if it is bad, hugo will completely fail.

**- Description for the changelog:** Include hugo as a npm dependency

**- A picture of a cute animal (not mandatory but encouraged)**

![Cat using a PC](https://i.imgflip.com/g7u55.jpg)
