### PR TITLE
Environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ You can use ES6 and use both relative imports or import libraries from npm.
 Any CSS file directly under the `src/css/` folder will get compiled with [PostCSS Next](http://cssnext.io/)
 to `/dist/css/{filename}.css`. Import statements will be resolved as part of the build
 
+## Environment variables
+
+Two seperate the development and production *- aka build -* stages, all gulp
+tasks run with a node environment variable named either `development` or 
+`production`.
+
+You can access the environment variable inside the theme files with 
+`getenv "NODE_ENV"`. See the following example for a conditional statement:
+
+    {{ if eq (getenv "NODE_ENV") "development" }}You're in development!{{ end }}
+
+All tasks starting with *build* set the environment variable to `production` - 
+the other will set it to `development`.
+
 ## Deploying to netlify
 
 - Push your clone to your own GitHub repository.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -10,13 +10,18 @@ import webpack from "webpack";
 import webpackConfig from "./webpack.conf";
 
 const browserSync = BrowserSync.create();
-const defaultArgs = ["-d", "../dist", "-s", "site", "-v"];
 
+// Hugo arguments
+const hugoArgsDefault = ["-d", "../dist", "-s", "site", "-v"];
+const hugoArgsPreview = ["--buildDrafts", "--buildFuture"];
+
+// Development tasks
 gulp.task("hugo", (cb) => buildSite(cb));
-gulp.task("hugo-preview", (cb) => buildSite(cb, ["--buildDrafts", "--buildFuture"]));
+gulp.task("hugo-preview", (cb) => buildSite(cb, hugoArgsPreview));
 
-gulp.task("build", ["css", "js", "hugo"]);
-gulp.task("build-preview", ["css", "js", "hugo-preview"]);
+// Build/production tasks
+gulp.task("build", ["css", "js"], (cb) => buildSite(cb, [], "production"));
+gulp.task("build-preview", ["css", "js"], (cb) => buildSite(cb, hugoArgsPreview, "production"));
 
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
@@ -50,8 +55,10 @@ gulp.task("server", ["hugo", "css", "js"], () => {
   gulp.watch("./site/**/*", ["hugo"]);
 });
 
-function buildSite(cb, options) {
-  const args = options ? defaultArgs.concat(options) : defaultArgs;
+function buildSite(cb, options, environment = "development") {
+  const args = options ? hugoArgsDefault.concat(options) : hugoArgsDefault;
+
+  process.env.NODE_ENV = environment;
 
   return spawn(hugoBin, args, {stdio: "inherit"}).on("close", (code) => {
     if (code === 0) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,6 +1,6 @@
 import gulp from "gulp";
-import { spawn } from "child_process";
-import hugoBin from "hugo-bin"
+import {spawn} from "child_process";
+import hugoBin from "hugo-bin";
 import gutil from "gulp-util";
 import postcss from "gulp-postcss";
 import cssImport from "postcss-import";

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,6 +23,7 @@ gulp.task("hugo-preview", (cb) => buildSite(cb, hugoArgsPreview));
 gulp.task("build", ["css", "js"], (cb) => buildSite(cb, [], "production"));
 gulp.task("build-preview", ["css", "js"], (cb) => buildSite(cb, hugoArgsPreview, "production"));
 
+// Compile CSS with PostCSS
 gulp.task("css", () => (
   gulp.src("./src/css/*.css")
     .pipe(postcss([cssImport({from: "./src/css/main.css"}), cssnext()]))
@@ -30,6 +31,7 @@ gulp.task("css", () => (
     .pipe(browserSync.stream())
 ));
 
+// Compile Javascript
 gulp.task("js", (cb) => {
   const myConfig = Object.assign({}, webpackConfig);
 
@@ -44,6 +46,7 @@ gulp.task("js", (cb) => {
   });
 });
 
+// Development server with browsersync
 gulp.task("server", ["hugo", "css", "js"], () => {
   browserSync.init({
     server: {
@@ -55,6 +58,9 @@ gulp.task("server", ["hugo", "css", "js"], () => {
   gulp.watch("./site/**/*", ["hugo"]);
 });
 
+/**
+ * Run hugo and build the site
+ */
 function buildSite(cb, options, environment = "development") {
   const args = options ? hugoArgsDefault.concat(options) : hugoArgsDefault;
 


### PR DESCRIPTION
**- Summary**

The environmental variables inside the gulp tasks make it easy to use them within theme files. It's now easy to have switch between environments where you might need another base-path (like for github pages) or maybe include a script for debugging.

You can query the environment variables within the theme with `getenv "NODE_ENV"` - it will return `development` for all hugo* tasks and `production` for all build* tasks.

I also fixed two linting errors, added some comments to the gulpfile and updated the Readme to include the latest additions.

**- Test plan**

I've added `{{ getenv "NODE_ENV" }}` to `site\layouts\index.html` and run `gulp hugo`, `gulp hugo-preview` and `gulp server` which all three would yield *development* in the resulting file. While `gulp build` and `gulp build-preview` wrote *production* to the created files. Same would work with the npm scripts.

**- Description for the changelog**

Added environment variables inside gulp tasks

**- A picture of a cute animal (not mandatory but encouraged)**

![monkey time](https://s-media-cache-ak0.pinimg.com/originals/49/14/3a/49143ac9e580a35a913aabe20c98732b.jpg)