### PR TITLE
Some - hopefully - nicer defaults

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -2,4 +2,10 @@ baseurl = "/"
 languageCode = "en-us"
 languageLang = "en"
 title = "My new Victor-Hugo site"
+
+# Remove the following line if you want to generate a RSS feed
 disableRSS = true
+
+# Categories and tags disabled for an easy start
+# Learn about taxonomies: https://gohugo.io/content-management/taxonomies/
+disableKinds = ["taxonomy","taxonomyTerm"]

--- a/site/config.toml
+++ b/site/config.toml
@@ -2,3 +2,4 @@ baseurl = "/"
 languageCode = "en-us"
 languageLang = "en"
 title = "My new Victor-Hugo site"
+disableRSS = true

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,3 +1,4 @@
 baseurl = "/"
 languageCode = "en-us"
-title = "My New Hugo Site"
+languageLang = "en"
+title = "My new Victor-Hugo site"

--- a/site/config.toml
+++ b/site/config.toml
@@ -3,9 +3,7 @@ languageCode = "en-us"
 languageLang = "en"
 title = "My new Victor-Hugo site"
 
-# Remove the following line if you want to generate a RSS feed
-disableRSS = true
-
-# Categories and tags disabled for an easy start
-# Learn about taxonomies: https://gohugo.io/content-management/taxonomies/
-disableKinds = ["taxonomy","taxonomyTerm"]
+# RSS, categories and tags disabled for an easy start
+# See configuration options for more details: 
+# https://gohugo.io/getting-started/configuration/#toml-configuration
+disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -2,4 +2,8 @@
 
 <h1>Hugo with Gulp, PostCSS and Webpack</h1>
 
+<p>
+  Hooray 🎉 - you've built this with <a href="https://github.com/netlify/victor-hugo">Victor-Hugo</a>!
+</p>
+
 {{ partial "footer" . }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,3 +1,4 @@
-<script src="/app.js"></script>
-</body>
+  <script src="app.js"></script>
+
+  </body>
 </html>

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,7 +1,9 @@
 <!doctype html>
-<html>
+<html lang="{{ $.Site.Language.Lang }}">
   <head>
-    <title>Hugo with Gulp and Webpack</title>
-    <link rel="stylesheet" href="/css/main.css"/>
+    <meta charset="utf-8">
+    <base href="{{ $.Site.BaseURL }}">
+    <title>{{ $.Site.Title }}</title>
+    <link rel="stylesheet" href="css/main.css"/>
   </head>
   <body>

--- a/src/css/imports/reset.css
+++ b/src/css/imports/reset.css
@@ -1,3 +1,9 @@
-body {
-  font-size: 16px;
+/*
+  Define your resets here or use something like Normalize.css if you like
+ */
+
+html,
+body{
+  margin: 0;
+  padding: 0;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,1 +1,14 @@
+/*
+  You can use import statements to include partials:
+ */
 @import "imports/reset.css";
+
+
+/*
+  Or add your statements here:
+ */
+body{
+  font-family: sans-serif;
+  font-size: 1em;
+  text-align: center;
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,1 +1,4 @@
 // JS Goes here - ES6 supported
+
+// Say hello
+console.log("🦊 Hello! Edit me in src/js/app.js");


### PR DESCRIPTION
**- Summary**

For beginners and hopefully others, these changes should bring better default settings to the generated output of the first build. I disabled the RSS feed and the taxonomies to clean up the dist folder. The `title` and `baseURL` are now pulled from config and are added to the page's head. I also added a language parameter to the configuration and for output inside the head. Also changed and added some placeholder code in CSS and JS.

**- Test plan**

I have run `gulp server` and `npm run build` to review the changes. If you have had build the site before, you must empty the build beforehand since hugo does not clean the dist folder.

**- Description for the changelog**

Nicer default values for config and theme

**- A picture of a cute animal (not mandatory but encouraged)**

![Mr. Fox](http://colaholicu.ro/wp-content/uploads/cute-fox.jpg)