### PR TITLE
Replace gulp.watch() with the gulp-watch package

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,6 +6,7 @@ import postcss from "gulp-postcss";
 import cssImport from "postcss-import";
 import cssnext from "postcss-cssnext";
 import BrowserSync from "browser-sync";
+import watch from "gulp-watch";
 import webpack from "webpack";
 import webpackConfig from "./webpack.conf";
 
@@ -53,9 +54,9 @@ gulp.task("server", ["hugo", "css", "js"], () => {
       baseDir: "./dist"
     }
   });
-  gulp.watch("./src/js/**/*.js", ["js"]);
-  gulp.watch("./src/css/**/*.css", ["css"]);
-  gulp.watch("./site/**/*", ["hugo"]);
+  watch("./src/js/**/*.js", () => { gulp.start(["js"]) });
+  watch("./src/css/**/*.css", () => { gulp.start(["css"]) });
+  watch("./site/**/*", () => { gulp.start(["hugo"]) });
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-postcss": "^6.1.1",
     "gulp-util": "^3.0.7",
+    "gulp-watch": "^4.3.11",
     "hugo-bin": "^0.12.0",
     "imports-loader": "^0.7.1",
     "postcss-cssnext": "^2.7.0",


### PR DESCRIPTION
Fixes #46 

**- Summary**

Currently you must stop the server/watcher and re-run to detect newly created files. This is cumbersome, and can be easily fixed by replacing the default `gulp.watch()` with the `gulp-watch` package (NPM).

**- Test plan**

```
npm install
npm run start
```

Terminal output before change == Terminal output after change

**- Description for the changelog**

`gulp.watch()` replaced with `gulp-watch` to detect new files