### PR TITLE
Extended viewport tag for iOS11

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <html lang="{{ $.Site.Language.Lang }}">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <base href="{{ $.Site.BaseURL }}">
     <title>{{ $.Site.Title }}</title>
     <link rel="stylesheet" href="css/main.css"/>


### PR DESCRIPTION
**- Summary**

As reported by [jhabdas](https://github.com/netlify/victor-hugo/pull/40#pullrequestreview-67828718) I added the viewport extension to match newer iOS11 devices.

**- Test plan**

Sadly none. Don't have any iOS11 device.

**- Description for the changelog**

Added viewport-fit=cover support for iOS11 devices with the new screens.