### PR TITLE
New Gulp task to move all the fonts in a flattened directory inside dist

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -2,6 +2,7 @@ import gulp from "gulp";
 import {spawn} from "child_process";
 import hugoBin from "hugo-bin";
 import gutil from "gulp-util";
+import flatten from "gulp-flatten";
 import postcss from "gulp-postcss";
 import cssImport from "postcss-import";
 import cssnext from "postcss-cssnext";
@@ -21,8 +22,8 @@ gulp.task("hugo", (cb) => buildSite(cb));
 gulp.task("hugo-preview", (cb) => buildSite(cb, hugoArgsPreview));
 
 // Build/production tasks
-gulp.task("build", ["css", "js"], (cb) => buildSite(cb, [], "production"));
-gulp.task("build-preview", ["css", "js"], (cb) => buildSite(cb, hugoArgsPreview, "production"));
+gulp.task("build", ["css", "js", "fonts"], (cb) => buildSite(cb, [], "production"));
+gulp.task("build-preview", ["css", "js", "fonts"], (cb) => buildSite(cb, hugoArgsPreview, "production"));
 
 // Compile CSS with PostCSS
 gulp.task("css", () => (
@@ -47,8 +48,16 @@ gulp.task("js", (cb) => {
   });
 });
 
+// Move all fonts in a flattened directory
+gulp.task('fonts', () => (
+  gulp.src("./src/fonts/**/*")
+    .pipe(flatten())
+    .pipe(gulp.dest("./dist/fonts"))
+    .pipe(browserSync.stream())
+));
+
 // Development server with browsersync
-gulp.task("server", ["hugo", "css", "js"], () => {
+gulp.task("server", ["hugo", "css", "js", "fonts"], () => {
   browserSync.init({
     server: {
       baseDir: "./dist"
@@ -56,6 +65,7 @@ gulp.task("server", ["hugo", "css", "js"], () => {
   });
   watch("./src/js/**/*.js", () => { gulp.start(["js"]) });
   watch("./src/css/**/*.css", () => { gulp.start(["css"]) });
+  watch("./src/fonts/**/*", () => { gulp.start(["fonts"]) });
   watch("./site/**/*", () => { gulp.start(["hugo"]) });
 });
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "file-loader": "^0.11.1",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
+    "gulp-flatten": "^0.3.1",
     "gulp-postcss": "^6.1.1",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.11",


### PR DESCRIPTION
**- Summary**
The idea is to add a new Gulp task in order to move all the fonts form `src/fonts` folder to a new directory `dist/fonts`. The new folder will not have sub-folder.

**- Motivation**

1. Keep all 'static' files inside the folder `src`
2. Make easier to declare the `@fontface` without messing up with folders paths

**- Test plan**

1. Run`npm install`: gulp-flatten correctly installed
2. Run `npm start`: new fonts added or removed are moved into`src/fonts`
3. Run `npm run build`: all fonts are moved into `src/fonts`

**- Description for the changelog**

New Gulp task to move all the fonts in a flattened directory inside dist.

**- A picture of a cute animal (not mandatory but encouraged)**
![Goats](https://user-images.githubusercontent.com/2866531/31970003-e6b4fc90-b916-11e7-87f7-82fb0c10490c.jpg)
