### PR TITLE
Check for Netlify deploy URLs in base tag

### DIFF
--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <base href="{{ $.Site.BaseURL }}">
+    <base href="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}">
     <title>{{ $.Site.Title }}</title>
     <link rel="stylesheet" href="css/main.css"/>
   </head>


### PR DESCRIPTION
**- Summary**

The `<base>` tag is currently set to Hugo's `$.Site.BaseURL`. This is great for production builds, but doesn't work well with Netlify deploy previews — anchors/network requests on deploy previews still point to the production server, making it difficult to test changes.

**- Test plan**

Tested on an existing site build and fresh install.

**- Description for the changelog**

This change checks for the `CONTEXT` env, then serves the `URL` or `DEPLOY_PRIME_URL` for production & previews, respectively - falling back to `$.Site.BaseURL`.
