### PR TITLE
Added start-preview script and server-preview task

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ or
 gulp server
 ```
 
+or for developing your website with `hugo server --buildDrafts --buildFuture`, use:
+
+```bash
+npm run start-preview
+```
+
+or
+
+```bash
+gulp server-preview
+```
+
 Then visit http://localhost:3000/ *- or a new browser windows popped-up already -* to preview your new website. BrowserSync will automatically reload the CSS or refresh the whole page, when stylesheets or content changes.
 
 ### Static build

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -20,6 +20,10 @@ const hugoArgsPreview = ["--buildDrafts", "--buildFuture"];
 gulp.task("hugo", (cb) => buildSite(cb));
 gulp.task("hugo-preview", (cb) => buildSite(cb, hugoArgsPreview));
 
+// Run server tasks
+gulp.task("server", ["hugo", "css", "js", "fonts"], (cb) => runServer(cb));
+gulp.task("server-preview", ["hugo-preview", "css", "js", "fonts"], (cb) => runServer(cb));
+
 // Build/production tasks
 gulp.task("build", ["css", "js", "fonts"], (cb) => buildSite(cb, [], "production"));
 gulp.task("build-preview", ["css", "js", "fonts"], (cb) => buildSite(cb, hugoArgsPreview, "production"));
@@ -56,7 +60,7 @@ gulp.task('fonts', () => (
 ));
 
 // Development server with browsersync
-gulp.task("server", ["hugo", "css", "js", "fonts"], () => {
+function runServer() {
   browserSync.init({
     server: {
       baseDir: "./dist"
@@ -66,7 +70,7 @@ gulp.task("server", ["hugo", "css", "js", "fonts"], () => {
   gulp.watch("./src/css/**/*.css", ["css"]);
   gulp.watch("./src/fonts/**/*", ["fonts"]);
   gulp.watch("./site/**/*", ["hugo"]);
-});
+};
 
 /**
  * Run hugo and build the site

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "gulp build",
     "build-preview": "gulp build-preview",
     "start": "gulp server",
+    "start-preview": "gulp server-preview",
     "lint": "eslint src"
   },
   "author": "",


### PR DESCRIPTION
**Summary**

For developing a hugo website, I use `hugo server --buildDrafts` because I want to see unfinished pages or posts. `npm run build-preview` is not sufficient because it regenerates page and then stop the server. I need to see unfinished pages continuously while development reloaded after each change. So I added:

1. Task `server-preview` into `gulpfile.babel.js`
2. Script `start-preview` into `package.json`
3. and updated `README.md`
